### PR TITLE
Require lunch targets to be product-release-variant

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -896,13 +896,6 @@ function lunch()
 
     check_product $product
 
-    local prebuilt_kernel=$(get_build_var TARGET_PREBUILT_KERNEL)
-    if [ -z "$prebuilt_kernel" ]; then
-      export INLINE_KERNEL_BUILDING=true
-    else
-      unset INLINE_KERNEL_BUILDING
-    fi
-
     [[ -n "${ANDROID_QUIET_BUILD:-}" ]] || echo
 
     fixup_common_out_dir

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -872,6 +872,13 @@ function lunch()
     # Note this is the string "release", not the value of the variable.
     export TARGET_BUILD_TYPE=release
 
+    local prebuilt_kernel=$(get_build_var TARGET_PREBUILT_KERNEL)
+    if [ -z "$prebuilt_kernel" ]; then
+      export INLINE_KERNEL_BUILDING=true
+    else
+      unset INLINE_KERNEL_BUILDING
+    fi
+
     [[ -n "${ANDROID_QUIET_BUILD:-}" ]] || echo
 
     fixup_common_out_dir

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -878,11 +878,11 @@ function lunch()
 
     set_stuff_for_environment
 
-#    if [ "${TARGET_BUILD_VARIANT}" = "userdebug" ] && [[  -z "${ANDROID_QUIET_BUILD}" ]]; then
-#      echo
-#      echo "Want FASTER LOCAL BUILDS? Use -eng instead of -userdebug (however for" \
-#        "performance benchmarking continue to use userdebug)"
-#    fi
+    if [ "${TARGET_BUILD_VARIANT}" = "userdebug" ] && [[  -z "${ANDROID_QUIET_BUILD}" ]]; then
+      echo
+      echo "Want FASTER LOCAL BUILDS? Use -eng instead of -userdebug (however for" \
+        "performance benchmarking continue to use userdebug)"
+    fi
     if [ $used_lunch_menu -eq 1 ]; then
       echo
       echo "Hint: next time you can simply run 'lunch $selection'"

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -56,7 +56,7 @@ cat <<EOF
 Run "m help" for help with the build system itself.
 
 Invoke ". build/envsetup.sh" from your shell to add the following functions to your environment:
-- lunch:      lunch <product_name>-<build_variant>
+- lunch:      lunch <product_name>-<release_type>-<build_variant>
               Selects <product_name> as the product to build, and <build_variant> as the variant to
               build, and stores those selections in the environment to be read by subsequent
               invocations of 'm' etc.
@@ -835,16 +835,16 @@ function lunch()
 
     export TARGET_BUILD_APPS=
 
-    # This must be <product>-<variant>
-    local product variant
+    # This must be <product>-<release>-<variant>
+    local product release variant
     # Split string on the '-' character.
-    IFS="-" read -r product variant <<< "$selection"
+    IFS="-" read -r product release variant <<< "$selection"
 
-    if [[ -z "$product" ]] || [[ -z "$variant" ]]
+    if [[ -z "$product" ]] || [[ -z "$release" ]] || [[ -z "$variant" ]]
     then
         echo
         echo "Invalid lunch combo: $selection"
-        echo "Valid combos must be of the form <product>-<variant>"
+        echo "Valid combos must be of the form <product>-<release>-<variant>"
         return 1
     fi
 

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -863,10 +863,6 @@ function lunch()
         cd - > /dev/null
     fi
 
-    # Always pick the latest release
-    release=$(grep "BUILD_ID" build/make/core/build_id.mk | tail -1 | cut -d '=' -f 2 | cut -d '.' -f 1 | tr '[:upper:]' '[:lower:]')
-    export TARGET_RELEASE=$release
-
     TARGET_PRODUCT=$product \
     TARGET_BUILD_VARIANT=$variant \
     TARGET_RELEASE=$release \
@@ -893,8 +889,6 @@ function lunch()
     export TARGET_RELEASE=$release
     # Note this is the string "release", not the value of the variable.
     export TARGET_BUILD_TYPE=release
-
-    check_product $product
 
     [[ -n "${ANDROID_QUIET_BUILD:-}" ]] || echo
 

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -785,23 +785,11 @@ function lunch()
 
     if [ "$1" ]; then
         answer=$1
-       if (echo -n $answer | grep -q -e "^[0-9][0-9]*$")
-        then
-            echo
-            echo "Invalid lunch combo"
-            return 1
-        fi
     else
         print_lunch_menu
-        echo -n "Which would you like? "
-        echo -n "Pick from common choices above (e.g. 13) or specify your own (e.g. aosp_barbet-ap1a-eng): "
+        echo "Which would you like? [aosp_arm-trunk_staging-eng]"
+        echo -n "Pick from common choices above (e.g. 13) or specify your own (e.g. aosp_barbet-trunk_staging-eng): "
         read answer
-        if ! (echo -n $answer | grep -q -e "^[0-9][0-9]*$")
-        then
-            echo
-            echo "Invalid lunch combo"
-            return 1
-        fi
         used_lunch_menu=1
     fi
 
@@ -809,13 +797,11 @@ function lunch()
 
     if [ -z "$answer" ]
     then
-       echo
-       echo "Invalid lunch combo"
-       return 1
+        selection=aosp_arm-trunk_staging-eng
     elif (echo -n $answer | grep -q -e "^[0-9][0-9]*$")
     then
         local choices=($(TARGET_BUILD_APPS= get_build_var COMMON_LUNCH_CHOICES))
-        if [ $answer -ge 1 ] && [ $answer -le ${#choices[@]} ]
+        if [ $answer -le ${#choices[@]} ]
         then
             # array in zsh starts from 1 instead of 0.
             if [ -n "$ZSH_VERSION" ]
@@ -824,10 +810,6 @@ function lunch()
             else
                 selection=${choices[$(($answer-1))]}
             fi
-       else
-            echo
-            echo "Invalid lunch combo"
-            return 1
         fi
     else
         selection=$answer


### PR DESCRIPTION
Instead of supporting both product-variant and
product-release-variant, we now require the release type to be given to use.

Bug: 307946156
Test: 'lunch aosp_mokey-userdebug' (now) fails; 'lunch aosp_mokey-trunk_staging-userdebug' (still) works
Change-Id: Ica87b3969f950a57232615f33bfe5f4012a743d6